### PR TITLE
chore(composer): use standard thelia-frontoffice-template type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
   "extra": {
     "installer-name": "flexy",
     "branch-alias": {
-      "dev-twig": "0.2.x-dev"
+      "dev-twig": "0.2.x-dev",
+      "dev-feat/use-standard-frontoffice-template-type": "0.2.x-dev"
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,9 @@
     }
   },
   "extra": {
-    "installer-name": "flexy"
+    "installer-name": "flexy",
+    "branch-alias": {
+      "dev-twig": "0.2.x-dev"
+    }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "thelia/flexy",
-  "type": "thelia-flexy",
+  "type": "thelia-frontoffice-template",
   "description": "thelia design system",
   "keywords": [
     "thelia-frontoffice-template",


### PR DESCRIPTION
## Why

When running `composer install`, the `thelia/flexy` package lands in `vendor/thelia/flexy/` instead of `templates/frontOffice/flexy/`, breaking the Thelia 3 install flow (FlexyBundle never gets registered, front-office template is missing).

Root cause: the package declares `"type": "thelia-flexy"`, but `composer/installers` v1 (used by Thelia 3 — see `composer.lock`) only honors a fixed list of types per framework. For Thelia, `TheliaInstaller` exposes:

- `thelia-module`
- `thelia-frontoffice-template`
- `thelia-backoffice-template`
- `thelia-email-template`

Custom types such as `thelia-flexy` are unmapped, so the package falls back to the vendor path. Extending the list would require composer/installers v2 (`installer-types`), which is a separate upgrade out of scope here.

## What

Switch the package type to the standard `thelia-frontoffice-template`. The keyword `thelia-frontoffice-template` is already declared (line 6 of `composer.json`), so the change matches the package's stated intent.

The `extra.installer-name = flexy` setting is unchanged, so the install path remains `templates/frontOffice/flexy/` as before.

## Effect

After this change, in a project consuming `thelia/flexy` via Composer with the standard installer-paths mapping (`templates/frontOffice/{name}` -> `type:thelia-frontoffice-template`), Flexy will be placed correctly.

A companion change in `thelia/thelia` updates the `installer-paths` mapping from `type:thelia-flexy` to `type:thelia-frontoffice-template`.

## Test plan

- [ ] Tag a release (or rely on `dev-twig`) and run a fresh `composer install` in `thelia/thelia` — verify `templates/frontOffice/flexy/src/FlexyBundle.php` exists and `vendor/thelia/flexy/` does not.