### PR TITLE
Backport/wpc

### DIFF
--- a/assets/controllers/header_controller.js
+++ b/assets/controllers/header_controller.js
@@ -1,26 +1,32 @@
 import { Controller } from '@hotwired/stimulus';
 
 class HeaderController extends Controller {
-  static targets = ['toggler', 'menu', 'close', 'back', 'sub'];
+  static targets = ['panel', 'back', 'sub'];
 
   constructor(arg) {
     super(arg);
     this.previous = 0;
   }
 
-  connect() {
-    this.togglerTarget?.addEventListener('click', () => {
-      this.menuTarget.classList.toggle('is-open');
-      this.togglerTarget.classList.toggle('is-selected');
-      document.body.classList.toggle('locked');
-    });
+  // data-action="header#togglePanel" data-header-panel-param="menu|lang|search"
+  togglePanel(event) {
+    const { panel: panelId } = event.params;
+    const target = this.#findPanel(panelId);
+    if (!target) return;
+
+    const isOpen = target.classList.contains('is-open');
+    this.#closeAll();
+
+    if (!isOpen) {
+      target.classList.add('is-open');
+      document.body.classList.add('locked');
+      event.currentTarget.classList.add('is-selected');
+    }
   }
 
   close() {
-    this.menuTarget.classList.remove('is-open');
-    this.backTarget.dataset.menuBack = -1;
-    this.togglerTarget.classList.remove('is-selected');
-    document.body.classList.remove('locked');
+    this.#closeAll();
+    if (this.hasBackTarget) this.backTarget.dataset.menuBack = -1;
     this.subTargets.forEach((sub) => sub.classList.remove('is-active'));
   }
 
@@ -49,7 +55,7 @@ class HeaderController extends Controller {
       this.previous = -1;
     }
 
-    displayBackBtn(this.backTarget, this.previous);
+    if (this.hasBackTarget) this.backTarget.dataset.menuBack = this.previous;
   }
 
   back(event) {
@@ -57,10 +63,18 @@ class HeaderController extends Controller {
       params: { item: event.currentTarget.dataset.menuBack }
     });
   }
-}
 
-function displayBackBtn(backBtn, previous) {
-  backBtn.dataset.menuBack = previous;
+  #findPanel(panelId) {
+    return this.panelTargets.find((p) => p.dataset.headerPanelId === panelId);
+  }
+
+  #closeAll() {
+    this.panelTargets.forEach((p) => p.classList.remove('is-open'));
+    document.body.classList.remove('locked');
+    this.element
+      .querySelectorAll('[data-header-panel-param]')
+      .forEach((btn) => btn.classList.remove('is-selected'));
+  }
 }
 
 export default HeaderController;

--- a/assets/controllers/item_header_controller.js
+++ b/assets/controllers/item_header_controller.js
@@ -17,8 +17,8 @@ class ItemHeaderController extends Controller {
       }
     });
   }
-  toggle({ target }) {
-    target.classList.toggle('is-open');
+  toggle({ currentTarget }) {
+    currentTarget.classList.toggle('is-open');
   }
 }
 

--- a/assets/css/blocks.css
+++ b/assets/css/blocks.css
@@ -1,0 +1,50 @@
+.BlockTable {
+  overflow: auto;
+  width: 100%;
+  border-radius: 8px;
+  border: 1px solid var(--theme-lighter);
+  margin: 2rem 0;
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  thead th {
+    background-color: var(--theme-medium);
+    color: var(--black);
+    font-weight: 700;
+    text-align: left;
+    padding: 12px 16px;
+    white-space: nowrap;
+  }
+
+  tbody tr:nth-child(even) {
+    background-color: var(--theme-lightest);
+  }
+
+  tbody td {
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--theme-lighter);
+    color: var(--black);
+    vertical-align: top;
+  }
+
+  tbody tr:last-child td {
+    border-bottom: none;
+  }
+
+  a {
+    text-decoration: underline;
+
+    &:hover {
+      color: var(--theme);
+    }
+  }
+}
+
+.tb-blockVideo {
+  border-radius: 8px;
+  margin: 1rem 0;
+  overflow: hidden;
+}

--- a/assets/css/menu.css
+++ b/assets/css/menu.css
@@ -85,17 +85,13 @@
   }
 }
 
-[data-menu-back] {
-  @apply lg:hidden p-[var(--padding-button-close)] absolute  top-0 z-10 -translate-y-1/2;
+.Button[data-menu-back] {
+  @apply lg:hidden absolute z-10 -translate-y-1/2;
 
   left: calc(var(--padding-x-menu) - var(--padding-button-close));
   top: calc(var(--padding-top-menu) / 2);
-
-  svg {
-    @apply w-[28px];
-  }
 }
 
-[data-menu-back='-1'] {
+.Button[data-menu-back='-1'] {
   display: none;
 }

--- a/assets/css/menu.css
+++ b/assets/css/menu.css
@@ -5,7 +5,35 @@
   --padding-button-close: 24px;
 }
 
-@media screen and (max-width: theme('screens.lg')) {
+/* ── Generic mobile fullscreen panel ── */
+
+.MobilePanel {
+  display: none;
+}
+
+@screen maxLg {
+  .MobilePanel {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: var(--header-nav-height);
+    display: none;
+    background-color: var(--white);
+    color: var(--black);
+    overflow-y: auto;
+    padding-top: var(--padding-top-menu);
+    padding-inline: var(--padding-x-menu);
+
+    &.is-open {
+      display: block;
+    }
+  }
+}
+
+/* ── Menu navigation ── */
+
+@screen maxLg {
   #Menu {
     @apply fixed inset-0 hidden text-black bg-white;
 

--- a/assets/css/wysiwyg.css
+++ b/assets/css/wysiwyg.css
@@ -1,0 +1,121 @@
+.wysiwyg {
+  color: var(--black);
+
+  h1 {
+    font-size: var(--font-size-h1-m);
+    font-weight: var(--font-weight-h1);
+    line-height: var(--line-height-h1-m);
+    font-family: var(--font-family-heading);
+    margin-bottom: 20px;
+    @screen lg {
+      font-size: var(--font-size-h1-d);
+      line-height: var(--line-height-h1-d);
+    }
+  }
+  h2 {
+    font-size: var(--font-size-h2-m);
+    font-weight: var(--font-weight-h2);
+    line-height: var(--line-height-h2-m);
+    font-family: var(--font-family-heading);
+    margin-bottom: 16px;
+    @screen lg {
+      font-size: var(--font-size-h2-d);
+      line-height: var(--line-height-h2-d);
+    }
+  }
+  h3 {
+    font-size: var(--font-size-h3-m);
+    font-weight: var(--font-weight-h3);
+    line-height: var(--line-height-h3-m);
+    font-family: var(--font-family-heading);
+    margin-bottom: 12px;
+    @screen lg {
+      font-size: var(--font-size-h3-d);
+      line-height: var(--line-height-h3-d);
+    }
+  }
+  h4 {
+    font-size: var(--font-size-h4-m);
+    font-weight: var(--font-weight-h4);
+    line-height: var(--line-height-h4-m);
+    margin-bottom: 10px;
+    @screen lg {
+      font-size: var(--font-size-h4-d);
+      line-height: var(--line-height-h4-d);
+    }
+  }
+  h5 {
+    font-size: var(--font-size-h5-m);
+    font-weight: var(--font-weight-h5);
+    line-height: var(--line-height-h5-m);
+    margin-bottom: 8px;
+    @screen lg {
+      font-size: var(--font-size-h5-d);
+      line-height: var(--line-height-h5-d);
+    }
+  }
+  h6 {
+    font-size: var(--font-size-h6-m);
+    font-weight: var(--font-weight-h6);
+    line-height: var(--line-height-h6-m);
+    margin-bottom: 8px;
+    @screen lg {
+      font-size: var(--font-size-h6-d);
+      line-height: var(--line-height-h6-d);
+    }
+  }
+
+  hr {
+    color: var(--grey-light);
+  }
+
+  li {
+    margin-bottom: 8px;
+    line-height: 1.6;
+    position: relative;
+    padding-left: 5px;
+  }
+
+  ul li {
+    list-style-type: disc;
+    margin-left: 40px;
+  }
+  ul {
+    margin-top: 20px;
+  }
+
+  ol li {
+    list-style-type: decimal;
+    margin-left: 20px;
+  }
+
+  ul ul li,
+  ol ol li {
+    margin-left: 15px;
+    margin-bottom: 5px;
+  }
+
+  ul li::marker,
+  ol li::marker {
+    color: var(--theme);
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    &:first-child {
+      margin-top: 0;
+    }
+  }
+
+  .ql-align-center {
+    text-align: center;
+  }
+
+  .ql-align-right {
+    text-align: right;
+  }
+}

--- a/blocks/blockAccordion.html.twig
+++ b/blocks/blockAccordion.html.twig
@@ -1,0 +1,20 @@
+<div class="tb-{{type.id}} my-4 md:my-8">
+	<div class="h3 mb-4">{{data.title}}</div>
+	{% for item in data.group %}
+		{% set itemContain = [] %}
+		{% for block in item.content %}
+			{% if block.type.id %}
+				{% set itemContain = itemContain|merge([block.type.id]) %}
+			{% endif %}
+		{% endfor %}
+
+		{% set content %}
+		<div data-tb-contain="{{ itemContain|join(' ') }}">
+			{{ getTheliaBLocksRenderedContent(item.content|json_encode)|raw }}
+		</div>
+		{% endset %}
+
+		{% include '@components/Molecules/Accordion/Accordion.html.twig' with { title: item.title, content: content, iconPlus: 'plus', iconMinus: 'minus'} %}
+
+	{% endfor %}
+</div>

--- a/blocks/blockGroup.html.twig
+++ b/blocks/blockGroup.html.twig
@@ -1,0 +1,13 @@
+<div class="tb-{{ type.id }}">
+    {% for item in data.content %}
+        {% set itemContain = [] %}
+        {% for block in item %}
+            {% if block.type.id %}
+                {% set itemContain = itemContain|merge([block.type.id]) %}
+            {% endif %}
+        {% endfor %}
+        <div data-tb-contain="{{ itemContain|join(' ') }}">
+            {{ getTheliaBLocksRenderedContent(item|json_encode)|raw }}
+        </div>
+    {% endfor %}
+</div>

--- a/blocks/blockHighlight.html.twig
+++ b/blocks/blockHighlight.html.twig
@@ -1,0 +1,3 @@
+<div class="tb-{{ type.id }} wysiwyg p-4" style="background-color: {{ data.style.backgroundColor }};">
+    {{ data.value|raw }}
+</div>

--- a/blocks/blockProduct.html.twig
+++ b/blocks/blockProduct.html.twig
@@ -1,0 +1,9 @@
+{% if data.productList is defined and data.productList|length > 0 %}
+<div class="tb-{{ type.id }} grid gap-8" style="grid-template-columns: repeat(auto-fill, minmax(280px, 1fr))">
+    {% for productId in data.productList %}
+        <div class="max-w-sm mx-auto w-full">
+            {{ component('Flexy:ProductCard', {productId: productId}) }}
+        </div>
+    {% endfor %}
+</div>
+{% endif %}

--- a/blocks/blockSeparator.html.twig
+++ b/blocks/blockSeparator.html.twig
@@ -1,0 +1,6 @@
+{% if data.type == 'hr' %}
+    {% set margin = (data.size * 0.25) ~ 'rem' %}
+    <hr class="tb-{{ type.id }}" style="margin-top: {{ margin }}; margin-bottom: {{ margin }};" />
+{% else %}
+    <div class="tb-{{ type.id }}" style="height: {{ (data.size * 0.5) ~ 'rem' }};"></div>
+{% endif %}

--- a/blocks/blockTable.html.twig
+++ b/blocks/blockTable.html.twig
@@ -1,0 +1,26 @@
+<div class="tb-{{ type.id }} BlockTable">
+    <table>
+        <thead>
+            <tr>
+                {% for header in data.headers %}
+                    <th>{{ header }}</th>
+                {% endfor %}
+            </tr>
+        </thead>
+        <tbody>
+            {% for row in data.rows %}
+                <tr>
+                    {% for item in row %}
+                        <td>
+                            {% if item.type == 'link' %}
+                                <a href="{{ item.value.link }}">{{ item.value.label }}</a>
+                            {% else %}
+                                {{ item.value }}
+                            {% endif %}
+                        </td>
+                    {% endfor %}
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>

--- a/blocks/blockText.html.twig
+++ b/blocks/blockText.html.twig
@@ -1,0 +1,1 @@
+<div class="tb-{{ type.id }} wysiwyg">{{ data.value|raw }}</div>

--- a/blocks/blockTitle.html.twig
+++ b/blocks/blockTitle.html.twig
@@ -1,0 +1,7 @@
+{% if data.text %}
+    {% if data.level %}
+        <h{{ data.level }} class="tb-{{ type.id }}" id="{{ data.text|slug_id(id) }}">{{ data.text|raw }}</h{{ data.level }}>
+    {% else %}
+        <p class="tb-{{ type.id }}" id="{{ data.text|slug_id(id) }}">{{ data.text|raw }}</p>
+    {% endif %}
+{% endif %}

--- a/blocks/blockVideo.html.twig
+++ b/blocks/blockVideo.html.twig
@@ -1,0 +1,11 @@
+{% if data.videoId %}
+<div class="tb-{{ type.id }} aspect-video">
+    <iframe
+        class="w-full h-full"
+        src="https://www.youtube.com/embed/{{ data.videoId }}"
+        loading="lazy"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen
+    ></iframe>
+</div>
+{% endif %}

--- a/blocks/multiColumns.html.twig
+++ b/blocks/multiColumns.html.twig
@@ -1,0 +1,13 @@
+<div class="tb-{{ type.id }} flex flex-col md:flex-row gap-8">
+    {% for column in data %}
+        {% set columnContain = [] %}
+        {% for block in column %}
+            {% if block.type.id %}
+                {% set columnContain = columnContain|merge([block.type.id]) %}
+            {% endif %}
+        {% endfor %}
+        <div class="flex-1" data-tb-contain="{{ columnContain|join(' ') }}">
+            {{ getTheliaBLocksRenderedContent(column|json_encode)|raw }}
+        </div>
+    {% endfor %}
+</div>

--- a/components/Layout/Header/Header.html.twig
+++ b/components/Layout/Header/Header.html.twig
@@ -27,7 +27,7 @@
         {% if type == 'searchbar' %}
             {{ component('Flexy:SearchBar') }}
         {% else %}
-            <nav id="Menu" data-header-target="menu">
+            <nav id="Menu" data-header-target="panel" data-header-panel-id="menu">
                 <button type="button" data-menu-back="-1" data-header-target="back" data-action="header#back">
                     {{ ux_icon('arrow-left') }}
                 </button>
@@ -43,7 +43,7 @@
         {{ include('@components/Organisms/HeaderNav/HeaderNav.html.twig') }}
     </div>
     {% if type == 'searchbar' %}
-        <nav id="Menu" class="Header-navWrap" data-header-target="menu">
+        <nav id="Menu" class="Header-navWrap" data-header-target="panel" data-header-panel-id="menu">
             <button type="button" data-menu-back="-1" data-header-target="back" data-action="header#back">
                 {{ ux_icon('arrow-left') }}
             </button>

--- a/components/Layout/Header/Header.html.twig
+++ b/components/Layout/Header/Header.html.twig
@@ -28,9 +28,9 @@
             {{ component('Flexy:SearchBar') }}
         {% else %}
             <nav id="Menu" data-header-target="panel" data-header-panel-id="menu">
-                <button type="button" data-menu-back="-1" data-header-target="back" data-action="header#back">
-                    {{ ux_icon('arrow-left') }}
-                </button>
+                <twig:Flexy:Button data-menu-back="-1" data-header-target="back" data-action="header#back" icon_left="chevron-left" size="small" color="minimal">
+                    {{ 'Menu'|trans }}
+                </twig:Flexy:Button>
                 <button type="button" data-menu-close data-action="header#close">
                     {{ ux_icon('close') }}
                 </button>
@@ -44,9 +44,9 @@
     </div>
     {% if type == 'searchbar' %}
         <nav id="Menu" class="Header-navWrap" data-header-target="panel" data-header-panel-id="menu">
-            <button type="button" data-menu-back="-1" data-header-target="back" data-action="header#back">
-                {{ ux_icon('arrow-left') }}
-            </button>
+            <twig:Flexy:Button data-menu-back="-1" data-header-target="back" data-action="header#back" icon_left="chevron-left" size="small" color="minimal">
+                {{ 'Menu'|trans }}
+            </twig:Flexy:Button>
             <button type="button" data-menu-close data-action="header#close">
                 {{ ux_icon('close') }}
             </button>

--- a/components/Layout/Subheader/TitleOnly/SubheaderTitle.html.twig
+++ b/components/Layout/Subheader/TitleOnly/SubheaderTitle.html.twig
@@ -6,7 +6,7 @@
 {% if position == 'centered' %}
     {% set classes = 'Subheader--centered' %}
 {% endif %}
-<div class="Subheader Subheader-titleOnly {{ classes }}">
+<div class="Subheader Subheader--titleOnly {{ classes }}">
     <div class="container mx-auto">
         <{{ tag }} class="Subheader-title">
             {{ title }}

--- a/components/Layout/Subheader/subheader.css
+++ b/components/Layout/Subheader/subheader.css
@@ -2,7 +2,7 @@
   background: var(--theme-lighter);
   display: flex;
   align-items: center;
-  &-titleOnly {
+  &--titleOnly {
     min-height: rem-convert(340px);
     padding: rem-convert(24px 0);
     @screen md {

--- a/components/Molecules/Pagination/Pagination.html.twig
+++ b/components/Molecules/Pagination/Pagination.html.twig
@@ -1,30 +1,34 @@
 {% set totalPages = (totalItems / itemsPerPage)|round(0, 'ceil')  %}
 {% if totalPages > 1 %}
-    <nav class="Pagination">
+    <nav class="Pagination" aria-label="{{ 'Pagination'|trans }}">
         <ul class="Pagination-list">
             {% if currentPage != 1 %}
-                <li class="Pagination-listItemPrev">
-                    <a href="?page={{ currentPage - 1 }}" class="Pagination-item Pagination-item--isPrev">
-                        <span class='Pagination-icon'>{{ ux_icon("chevron-left") }}</span>
-                        <span class='Pagination-text'>{{ 'Previous'|trans }}</span>
-                    </a>
+                <li class="mr-3">
+                    {{ component('Flexy:Button', {
+                        text: 'Previous'|trans,
+                        icon_left: 'chevron-left',
+                        color: 'minimal',
+                        href: (baseUrl ? baseUrl ~ '&' : '?') ~ 'page=' ~ (currentPage - 1),
+                    }) }}
                 </li>
             {% endif %}
 
             {% for page in 1..totalPages %}
-                <li class="Pagination-item">
-                    <a href="{{ baseUrl ? baseUrl ~ '&': '?'}}page={{ page }}" class="Pagination-item  {{ page == currentPage ? 'Pagination-item--active' }}">
+                <li>
+                    <a href="{{ baseUrl ? baseUrl ~ '&' : '?'}}page={{ page }}" class="Pagination-item {{ page == currentPage ? 'Pagination-item--active' }}">
                         {{ page }}
                     </a>
                 </li>
             {% endfor %}
 
             {% if currentPage != totalPages %}
-                <li class="Pagination-listItemNext">
-                    <a href="{{ baseUrl ? baseUrl ~ '&': '?'}}page={{ currentPage + 1 }}" class="Pagination-item Pagination-item--isNext">
-                        <span class='Pagination-text'>{{ 'Next'|trans }}</span>
-                        <span class='Pagination-icon'>{{ ux_icon("chevron-right") }}</span>
-                    </a>
+                <li class="ml-3">
+                    {{ component('Flexy:Button', {
+                        text: 'Next'|trans,
+                        icon_right: 'chevron-right',
+                        color: 'minimal',
+                        href: (baseUrl ? baseUrl ~ '&' : '?') ~ 'page=' ~ (currentPage + 1),
+                    }) }}
                 </li>
             {% endif %}
         </ul>

--- a/components/Molecules/Pagination/pagination.css
+++ b/components/Molecules/Pagination/pagination.css
@@ -14,59 +14,20 @@
     display: inline-flex;
     justify-content: center;
     align-items: center;
+    border-radius: rem-convert(8px);
 
     a&:hover {
       background-color: var(--grey-lightest);
       color: var(--grey);
     }
 
-    &:focus-visible{
+    &:focus-visible {
       outline: var(--theme-medium) solid 2px;
     }
 
     &--active {
       color: var(--theme-dark);
     }
-
-    @media screen and (min-width: 768px) {
-      &--isPrev {
-        padding: 0 rem-convert(12px) 0 rem-convert(4px);
-
-        .Pagination-text {
-          margin-left: rem-convert(6px);
-        }
-      }
-
-      &--isNext {
-        padding: 0 rem-convert(4px) 0 rem-convert(12px);
-
-        .Pagination-text {
-          margin-right: rem-convert(6px);
-        }
-      }
-    }
   }
 
-  &-listItemPrev {
-    margin-right: rem-convert(12px);
-  }
-
-  &-listItemNext {
-    margin-left: rem-convert(12px);
-  }
-
-  &-icon {
-    width: rem-convert(21px);
-    height: rem-convert(21px);
-    display: inline-block;
-    color: var(--black);
-  }
-
-  &-text {
-    display: none;
-
-    @media screen and (min-width: 768px) {
-      display: inline;
-    }
-  }
 }

--- a/components/Organisms/Card/Article/article.css
+++ b/components/Organisms/Card/Article/article.css
@@ -1,10 +1,11 @@
 .Article {
   height: 98px;
   display: flex;
-  &-img {
-    border-top-left-radius: rem-convert(8px);
-    border-bottom-left-radius: rem-convert(8px);
-  }
+  text-decoration: none;
+  border: 1px solid var(--theme-lighter);
+  border-radius: rem-convert(8px);
+  overflow: hidden;
+
   &-content {
     padding-right: rem-convert(16px);
     padding-left: rem-convert(16px);
@@ -14,8 +15,6 @@
     flex-direction: column;
     justify-content: space-between;
     background: var(--white);
-    border-top-right-radius: rem-convert(8px);
-    border-bottom-right-radius: rem-convert(8px);
     flex-grow: 1;
   }
   &-title {
@@ -25,5 +24,9 @@
   &-date {
     @apply paragraph-6;
     color: var(--grey);
+  }
+
+  &:hover &-title {
+    text-decoration: underline;
   }
 }

--- a/components/Organisms/HeaderNav/HeaderNav.html.twig
+++ b/components/Organisms/HeaderNav/HeaderNav.html.twig
@@ -23,13 +23,12 @@
         small: true
     }) }}
     {{ component('Flexy:HeaderButton', {
-        href: path('checkout_cart'),
         icon: 'menu',
         color: 'light',
-        id: 'toggleMenu',
         class: "HeaderNav-btn lg:hidden",
-        text: 'Cart'|trans,
+        text: 'Menu'|trans,
         small: true,
-        'data-header-target': "toggler"
+        'data-action': 'header#togglePanel',
+        'data-header-panel-param': 'menu'
     }) }}
 </div>

--- a/components/base.css
+++ b/components/base.css
@@ -7,6 +7,10 @@
 @import 'tailwindcss/utilities';
 @import url('../src/UiComponents/**/*.css');
 
+html {
+  scroll-behavior: smooth;
+}
+
 body {
   font-family: 'Poppins', 'Roboto', serif;
   color: var(--black);

--- a/content.html.twig
+++ b/content.html.twig
@@ -13,7 +13,7 @@
 	<div class="container flex gap-[173px] pt-[25px] lg:pt-[54px] pb-[80px] lg:pb-[120px]">
 		<article class="wysiwyg">
 			<div>
-				{{ attr('content', 'description') }}
+				{{ attr('content', 'description')|raw }}
 			</div>
 			{{ component('Flexy:Blocks', {item_type: 'content', item_id: attr('content', 'id')}) }}
 			{% if ps %}

--- a/content.html.twig
+++ b/content.html.twig
@@ -10,28 +10,35 @@
         id: attr('content', 'id'),
     })}}
 
-	<div class="container flex gap-[173px] pt-[25px] lg:pt-[54px] pb-[80px] lg:pb-[120px]">
-		<article class="wysiwyg">
-			<div>
-				{{ attr('content', 'description')|raw }}
-			</div>
-			{{ component('Flexy:Blocks', {item_type: 'content', item_id: attr('content', 'id')}) }}
-			{% if ps %}
-				<small>{{ ps }}</small>
-			{% endif %}
+	<div class="container pt-[25px] lg:pt-[54px] pb-[80px] lg:pb-[120px]">
+		<div class="xl:flex xl:gap-12 xl:items-start">
+			<article class="wysiwyg flex flex-col gap-10 min-w-0 flex-1">
+				<div>
+					{{ attr('content', 'description')|raw }}
+				</div>
+				{{ component('Flexy:Blocks', {item_type: 'content', item_id: attr('content', 'id')}) }}
+				{% if ps %}
+					<small>{{ ps }}</small>
+				{% endif %}
+			</article>
 
-		</article>
+            {% block table_of_contents %}
+			    {{ component('Flexy:BlocksToc', {item_type: 'content', item_id: attr('content', 'id'), max_level: 3}) }}
+            {% endblock %}
+		</div>
 	</div>
 
-	<div class="bg-theme-lighter">
-		{{
-            component('Flexy:SimilarContent', {
-                title: 'On the same topic'|trans,
-                button: {
-                    label: 'See all news'|trans,
-                    href: '/'
-                },
-            })
-        }}
-	</div>
+    {% block similar_content %}
+        <div class="bg-theme-lighter">
+            {{
+                component('Flexy:SimilarContent', {
+                    title: 'On the same topic'|trans,
+                    button: {
+                        label: 'See all news'|trans,
+                        href: '/'
+                    },
+                })
+            }}
+        </div>
+    {% endblock %}
 {% endblock %}

--- a/folder.html.twig
+++ b/folder.html.twig
@@ -1,6 +1,5 @@
 {% extends 'base.html.twig' %}
 
-{% set contents = resources('/api/front/contents', {'contentFolders.folder.id': attr('folder', 'id')}) %}
 {% set childFolders = resources('/api/front/folders', {parent: attr('folder', 'id')}) %}
 {% set ps = attr('folder', 'postscriptum') %}
 
@@ -28,20 +27,10 @@
                 </ul>
             {% endif %}
 
-            {% if contents|length %}
-                <ul class="grid grid-cols-3 gap-4 my-8">
-                    {% for content in contents %}
-                        <li>
-                            {{ include('@components/Organisms/Card/Article/Article.html.twig', {
-                id: content.id,
-                source: 'content',
-                href: content.publicUrl,
-                title: content.i18ns.title,
-                }) }}
-                        </li>
-                    {% endfor %}
-                </ul>
-            {% endif %}
+            {{ component('Flexy:FolderContents', {
+                folderId: attr('folder', 'id'),
+                page: app.request.query.getInt('page', 1)
+            }) }}
 
             {% if ps %}
                 <small>{{ ps }}</small>

--- a/folder.html.twig
+++ b/folder.html.twig
@@ -8,20 +8,21 @@
     {{ include('@components/Layout/Subheader/ContentPage/SubheaderContentPage.html.twig', {title: attr('folder', 'title'), description: attr('folder', 'chapo')}) }}
 
     <div class="px-[25px] lg:pr-[225px] lg:pl-[250px] xl:pr-[325px] xl:pl-[350px] flex gap-[173px] mt-[25px] lg:mt-[54px] mb-[80px] lg:mb-[120px]">
-        <article class="wysiwyg">
-            {{ attr('folder', 'description') }}
-            {{ component('Flexy:Blocks', {item_type: 'folder', item_id: attr('folder', 'id')}) }}
-
+        <article>
+            <div class="wysiwyg">
+                {{ attr('folder', 'description')|raw }}
+                {{ component('Flexy:Blocks', {item_type: 'folder', item_id: attr('folder', 'id')}) }}
+            </div>
             {% if childFolders|length %}
                 <ul class="grid gap-4 my-8 md:grid-cols-3">
                     {% for folder in childFolders %}
                         <li>
                             {{ include('@components/Organisms/Card/Article/Article.html.twig', {
-                id: folder.id,
-                source: 'folder',
-                href: folder.publicUrl,
-                title: 'Titre',
-                }) }}
+                                id: folder.id,
+                                source: 'folder',
+                                href: folder.publicUrl,
+                                title: 'Titre',
+                            }) }}
                         </li>
                     {% endfor %}
                 </ul>

--- a/src/Controller/AccountController.php
+++ b/src/Controller/AccountController.php
@@ -27,7 +27,6 @@ use Thelia\Core\Event\TheliaEvents;
 use Thelia\Domain\Addressing\Service\AddressService;
 use Thelia\Form\Definition\FrontForm;
 use Thelia\Form\Exception\FormValidationException;
-use Thelia\Log\Tlog;
 use Thelia\Model\Base\AddressQuery;
 use Thelia\Model\Customer;
 use Thelia\Model\Event\AddressEvent;
@@ -94,7 +93,7 @@ class AccountController extends FlexyController
         }
         $this->getParserContext()->set('address_id', $addressId);
 
-        Tlog::getInstance()->error(\sprintf('Error during address creation process : %s', $message));
+        $this->logger->error(\sprintf('Error during address creation process : %s', $message));
 
         $addressUpdate->setErrorMessage($message);
 
@@ -132,7 +131,7 @@ class AccountController extends FlexyController
             $message = $this->getTranslator()->trans('Please check your input: %s', ['%s' => $e->getMessage()], Front::MESSAGE_DOMAIN);
         }
 
-        Tlog::getInstance()->error(\sprintf('Error during address creation process : %s', $message));
+        $this->logger->error(\sprintf('Error during address creation process : %s', $message));
 
         $addressCreate->setErrorMessage($message);
 
@@ -180,7 +179,7 @@ class AccountController extends FlexyController
         $eventDispatcher->dispatch(new AddressEvent($address), TheliaEvents::ADDRESS_DELETE);
 
 
-        Tlog::getInstance()->error(\sprintf('Error during address deletion : %s', $error_message));
+        $this->logger->error(\sprintf('Error during address deletion : %s', $error_message));
 
         // If Ajax Request
         if ($this->getRequest()->isXmlHttpRequest()) {
@@ -275,7 +274,7 @@ class AccountController extends FlexyController
             );
         }
 
-        Tlog::getInstance()->error(
+        $this->logger->error(
             \sprintf(
                 'Error during customer password modification process : %s.',
                 $message

--- a/src/Controller/CheckoutController.php
+++ b/src/Controller/CheckoutController.php
@@ -29,7 +29,6 @@ use Thelia\Domain\Checkout\Exception\EmptyCartException;
 use Thelia\Domain\Checkout\Exception\InvalidDeliveryException;
 use Thelia\Domain\Checkout\Exception\MissingAddressException;
 use Thelia\Domain\Shipping\ShippingFacade;
-use Thelia\Log\Tlog;
 
 #[Route('/checkout', name: 'checkout_')]
 class CheckoutController extends FlexyController

--- a/src/Controller/CustomerController.php
+++ b/src/Controller/CustomerController.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Thelia\Core\Event\DefaultActionEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Security\Authentication\CustomerUsernamePasswordFormAuthenticator;
@@ -38,7 +38,6 @@ use Thelia\Domain\Customer\Service\CustomerUpdateService;
 use Thelia\Domain\Marketing\Service\NewsletterSubscriber;
 use Thelia\Form\CustomerLogin;
 use Thelia\Form\Exception\FormValidationException;
-use Thelia\Log\Tlog;
 use Thelia\Model\ConfigQuery;
 use Thelia\Model\Customer;
 use Thelia\Model\CustomerQuery;
@@ -124,7 +123,7 @@ class CustomerController extends FlexyController
             );
         }
 
-        Tlog::getInstance()->error(
+        $this->logger->error(
             \sprintf(
                 'Error during customer login process : %s. Exception was %s',
                 $message,
@@ -177,7 +176,7 @@ class CustomerController extends FlexyController
             $message = $this->translator->trans('Please check your input: %s', ['%s' => $e->getMessage()]);
         }
 
-        Tlog::getInstance()->error(\sprintf('Error during address creation process : %s', $message));
+        $this->logger->error(\sprintf('Error during address creation process : %s', $message));
         $form->setErrorMessage($message);
 
         $this->parserContext
@@ -259,7 +258,7 @@ class CustomerController extends FlexyController
             $message = $this->getTranslator()->trans('Please check your input: %s', ['%s' => $e->getMessage()]);
         }
 
-        Tlog::getInstance()->error(\sprintf('Error during address creation process : %s', $message));
+        $this->logger->error(\sprintf('Error during address creation process : %s', $message));
         $form->setErrorMessage($message);
 
         $this->getParserContext()
@@ -366,7 +365,7 @@ class CustomerController extends FlexyController
             $message = $this->translator->trans('Please check your input: %s', ['%s' => $e->getMessage()]);
         }
 
-        Tlog::getInstance()->error(\sprintf('Error during address creation process : %s', $message));
+        $this->logger->error(\sprintf('Error during address creation process : %s', $message));
         $form->setErrorMessage($message);
 
         $this->parserContext

--- a/src/Controller/FlexyController.php
+++ b/src/Controller/FlexyController.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace FlexyBundle\Controller;
 
+use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
@@ -50,8 +51,8 @@ class FlexyController extends BaseController
         public TheliaFormFactory $theliaFormFactory,
         protected readonly FrontSecurityServiceInterface $securityService,
         protected readonly RouterInterface $router,
-    ) {
-    }
+        protected readonly LoggerInterface $logger,
+    ) {}
 
     public function getControllerType(): string
     {

--- a/src/Controller/PasswordController.php
+++ b/src/Controller/PasswordController.php
@@ -18,11 +18,10 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Thelia\Core\Event\LostPasswordEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Form\Exception\FormValidationException;
-use Thelia\Log\Tlog;
 
 #[Route('/password', name: 'password_')]
 class PasswordController extends FlexyController

--- a/src/Twig/SlugIdExtension.php
+++ b/src/Twig/SlugIdExtension.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlexyBundle\Twig;
+
+use Symfony\Component\String\Slugger\AsciiSlugger;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+class SlugIdExtension extends AbstractExtension
+{
+    private readonly AsciiSlugger $slugger;
+
+    public function __construct()
+    {
+        $this->slugger = new AsciiSlugger('fr');
+    }
+
+    public function getFilters(): array
+    {
+        return [
+            new TwigFilter('slug_id', $this->slugId(...)),
+        ];
+    }
+
+    /**
+     * Builds a human-readable, URL-safe identifier from a text and an opaque ID.
+     *
+     * The result combines a truncated ASCII slug of the text with a short prefix
+     * of the ID, separated by a dash. This gives both readability and uniqueness
+     * without relying solely on the raw ID.
+     *
+     * Example: slugId('Dératisation Paris', 'zzofpQnG4x', 40) → 'deratisation-paris-zzofpQ'
+     *
+     * @param string $text      Source text to slugify (HTML tags are stripped first)
+     * @param string $id        Opaque unique identifier; only its first $idLength chars are used
+     * @param int    $maxLength Maximum length of the slug part (default: 40)
+     * @param int    $idLength  Number of characters taken from $id (default: 6)
+     */
+    public function slugId(string $text, string $id, int $maxLength = 40, int $idLength = 6): string
+    {
+        $slug = (string) $this->slugger->slug(strip_tags($text))->lower();
+
+        if (mb_strlen($slug) > $maxLength) {
+            $slug = rtrim(mb_substr($slug, 0, $maxLength), '-');
+        }
+
+        return $slug . '-' . substr($id, 0, $idLength);
+    }
+}

--- a/src/UiComponents/BlocksToc/BlocksToc.css
+++ b/src/UiComponents/BlocksToc/BlocksToc.css
@@ -1,0 +1,46 @@
+.BlocksToc {
+  top: calc(var(--header-height) + 16px);
+}
+
+.tb-blockTitle {
+  scroll-margin-top: calc(var(--header-height) + 16px);
+}
+
+.BlocksToc-inner {
+  background-color: var(--white);
+  border-radius: rem-convert(10px);
+  padding: rem-convert(16px) rem-convert(24px);
+}
+
+.BlocksToc-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+
+  li {
+    display: flex;
+    align-items: center;
+    min-height: rem-convert(56px);
+    border-bottom: 1px solid var(--grey-lighter);
+
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+}
+
+.BlocksToc-link {
+  flex: 1;
+  padding: rem-convert(12px) rem-convert(8px);
+  color: var(--black);
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--theme);
+    outline-offset: 2px;
+  }
+}

--- a/src/UiComponents/BlocksToc/BlocksToc.html.twig
+++ b/src/UiComponents/BlocksToc/BlocksToc.html.twig
@@ -1,0 +1,17 @@
+{% if titles|length > 0 %}
+<aside class="BlocksToc hidden xl:block shrink-0 sticky self-start" style="width: 340px;" aria-label="{{ 'On this page'|trans }}">
+    <div class="BlocksToc-inner">
+        <nav>
+            <ul class="BlocksToc-list">
+                {% for title in titles %}
+                    <li>
+                        <a href="#{{ title.text|slug_id(title.id) }}" class="BlocksToc-link paragraph-2 paragraph--semibold">
+                            <span class="line-clamp-2">{{ title.text }}</span>
+                        </a>
+                    </li>
+                {% endfor %}
+            </ul>
+        </nav>
+    </div>
+</aside>
+{% endif %}

--- a/src/UiComponents/BlocksToc/BlocksToc.php
+++ b/src/UiComponents/BlocksToc/BlocksToc.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FlexyBundle\UiComponents\BlocksToc;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
+use Thelia\Core\HttpFoundation\Session\Session;
+use TheliaBlocks\Model\BlockGroupQuery;
+
+#[AsTwigComponent(name: 'Flexy:BlocksToc', template: '@UiComponents/BlocksToc/BlocksToc.html.twig')]
+class BlocksToc
+{
+    public ?string $item_type = null;
+
+    public ?string $item_id = null;
+
+    /** When set, only blockTitle blocks with a level ≤ this value are included. Neutral titles (no level) are excluded when a max level is set. */
+    public ?int $max_level = null;
+
+    public function __construct(
+        private readonly RequestStack $requestStack,
+    ) {
+    }
+
+    #[ExposeInTemplate]
+    public function getTitles(): array
+    {
+        $session = $this->requestStack->getCurrentRequest()?->getSession();
+        $locale = $session instanceof Session ? $session->getLang()?->getLocale() : null;
+
+        $search = BlockGroupQuery::create()
+            ->filterByVisible(1)
+            ->useItemBlockGroupQuery()
+                ->filterByItemType($this->item_type)
+                ->filterByItemId((int) $this->item_id)
+            ->endUse();
+
+        $titles = [];
+        foreach ($search->find() as $blockGroup) {
+            if ($locale !== null) {
+                $blockGroup->setLocale($locale);
+            }
+
+            try {
+                $blocks = json_decode($blockGroup->getJsonContent(), true, 512, \JSON_THROW_ON_ERROR);
+                if (!\is_array($blocks)) {
+                    continue;
+                }
+                foreach ($blocks as $block) {
+                    if (
+                        !isset($block['id'], $block['type']['id'], $block['data']['text'])
+                        || $block['type']['id'] !== 'blockTitle'
+                        || $block['data']['text'] === ''
+                    ) {
+                        continue;
+                    }
+
+                    $level = isset($block['data']['level']) ? (int) $block['data']['level'] : null;
+
+                    if ($this->max_level !== null && ($level === null || $level > $this->max_level)) {
+                        continue;
+                    }
+
+                    $titles[] = [
+                        'id' => $block['id'],
+                        'text' => strip_tags((string) $block['data']['text']),
+                    ];
+                }
+            } catch (\JsonException) {
+                // skip malformed block group
+            }
+        }
+
+        return $titles;
+    }
+}

--- a/src/UiComponents/FolderContents/FolderContents.html.twig
+++ b/src/UiComponents/FolderContents/FolderContents.html.twig
@@ -1,0 +1,20 @@
+{% if contents|length %}
+    <ul class="grid gap-4 my-8 grid-cols-[repeat(auto-fill,minmax(240px,1fr))]">
+        {% for content in contents %}
+            <li>
+                {{ include('@components/Organisms/Card/Article/Article.html.twig', {
+                    id: content.id,
+                    source: 'content',
+                    href: content.publicUrl,
+                    title: content.i18ns.title,
+                    date: content.publishedAt|date('d/m/Y'),
+                }) }}
+            </li>
+        {% endfor %}
+    </ul>
+    {% if pagination.totalItems > pagination.itemsPerPage %}
+        <div class="flex justify-center">
+            {% include '@components/Molecules/Pagination/Pagination.html.twig' with pagination %}
+        </div>
+    {% endif %}
+{% endif %}

--- a/src/UiComponents/FolderContents/FolderContents.php
+++ b/src/UiComponents/FolderContents/FolderContents.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FlexyBundle\UiComponents\FolderContents;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+use Thelia\Api\Service\DataAccess\DataAccessService;
+
+#[AsTwigComponent(name: 'Flexy:FolderContents', template: '@UiComponents/FolderContents/FolderContents.html.twig')]
+class FolderContents
+{
+    public const ITEMS_PER_PAGE = 12;
+
+    public array $contents = [];
+    public array $pagination = [];
+
+    public function __construct(
+        private readonly DataAccessService $dataAccessService,
+    ) {}
+
+    public function mount(int $folderId, int $page = 1): void
+    {
+        $response = $this->dataAccessService->resources('/api/front/contents', [
+            'contentFolders.folder.id' => $folderId,
+            'itemsPerPage' => self::ITEMS_PER_PAGE,
+            'page' => $page,
+        ], 'jsonld');
+
+        $this->contents = $response['hydra:member'] ?? [];
+        $this->pagination = [
+            'totalItems' => $response['hydra:totalItems'] ?? 0,
+            'itemsPerPage' => self::ITEMS_PER_PAGE,
+            'currentPage' => $page,
+            'baseUrl' => '',
+        ];
+    }
+}

--- a/src/UiComponents/LangSelect/LangSelect.css
+++ b/src/UiComponents/LangSelect/LangSelect.css
@@ -90,4 +90,50 @@
       opacity: 1;
     }
   }
+
+  &-mobileList {
+    list-style: none;
+    padding: 0;
+  }
+
+  &-mobileItem {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 16px;
+    margin-bottom: 2px;
+    height: 72px;
+    border-radius: 8px;
+    color: var(--black);
+    text-decoration: none;
+    transition: background-color 0.15s ease;
+
+    @apply paragraph-2 paragraph--semibold;
+
+    &:hover,
+    &:focus {
+      background-color: var(--grey-lightest);
+    }
+
+    &.active {
+      background-color: var(--grey-lightest);
+
+      .LangSelect-check {
+        color: var(--theme);
+      }
+    }
+
+    .LangSelect-flag {
+      @apply rounded-full;
+      width: 24px;
+      height: 24px;
+    }
+
+    .LangSelect-check {
+      margin-left: auto;
+      width: 24px;
+      height: 24px;
+      color: var(--theme);
+    }
+  }
 }

--- a/src/UiComponents/LangSelect/LangSelect.html.twig
+++ b/src/UiComponents/LangSelect/LangSelect.html.twig
@@ -21,4 +21,36 @@
             </ul>
         {% endif %}
     </div>
+
+    {{ component('Flexy:HeaderButton', {
+        icon: 'flags:' ~ currentLang.code,
+        color: 'light',
+        small: true,
+        text: currentLang.title,
+        class: 'md:hidden',
+        'data-action': 'header#togglePanel',
+        'data-header-panel-param': 'lang'
+    }) }}
+
+    <div class="MobilePanel" data-header-target="panel" data-header-panel-id="lang">
+        <button type="button" data-menu-close data-action="header#close">
+            {{ ux_icon('close') }}
+        </button>
+        <p class="h3 mb-7">{{ 'Language'|trans }}</p>
+        {% if langs|length %}
+            <ul class="LangSelect-mobileList">
+                {% for lang in langs %}
+                    <li>
+                        <a href="{{ attr('config', 'url_site') ~ '?' ~ {lang: lang.locale}|url_encode }}" class="LangSelect-mobileItem {% if currentLang.code == lang.code %}active{% endif %}">
+                            {{ ux_icon('flags:' ~ lang.code, {class: 'LangSelect-flag'}) }}
+                            <span>{{ lang.title }}</span>
+                            {% if currentLang.code == lang.code %}
+                                {{ ux_icon('checkmark', {class: 'LangSelect-check'}) }}
+                            {% endif %}
+                        </a>
+                    </li>
+                {% endfor %}
+            </ul>
+        {% endif %}
+    </div>
 {% endif %}

--- a/src/UiComponents/Pages/Product/Product.html.twig
+++ b/src/UiComponents/Pages/Product/Product.html.twig
@@ -1,10 +1,7 @@
 <div class="col-span-full ProductPage-grid" {{ attributes.defaults(stimulus_controller('product')) }} data-product-current-pse-id-value="{{ currentPse.id }}">
 	<section id="gallery" class="ProductPage-gallery">
     	{{ include('@components/Layout/ProductGallery/ProductGallery.html.twig', {
-    	    images: psesImgs|merge(productImgs|map(img => ({
-    			id: img.id,
-    			isProductImg: true
-    		})))
+    	    images: images
     	}) }}
 	</section>
 	<section id="infos" class="ProductPage-infos">

--- a/src/UiComponents/Pages/Product/Product.php
+++ b/src/UiComponents/Pages/Product/Product.php
@@ -50,10 +50,7 @@ class Product
     public ?array $availablePses = [];
 
     #[LiveProp]
-    public ?array $psesImgs = [];
-
-    #[LiveProp]
-    public ?array $productImgs = [];
+    public array $images = [];
 
     #[LiveProp]
     public ?array $productAttrs = [];
@@ -299,9 +296,9 @@ class Product
             ]
         );
 
-        $this->psesImgs = $this->getUniquePseImg($images, $imagesPdt);
+        $psesImgs = $this->getUniquePseImg($images, $imagesPdt);
 
-        $this->productImgs = array_filter($imagesPdt, static function ($img) use ($images) {
+        $productImgs = array_filter($imagesPdt, static function ($img) use ($images) {
             foreach ($images as $pseImg) {
                 if ($pseImg['productImageId'] === $img['id']) {
                     return false;
@@ -310,6 +307,11 @@ class Product
 
             return true;
         });
+
+        $this->images = array_merge(
+            $psesImgs,
+            array_map(static fn(array $img) => [...$img, 'isProductImg' => true], array_values($productImgs))
+        );
     }
 
     private function getUniquePseImg(array $images, array $productImages): array

--- a/src/UiComponents/SearchBar/SearchBar.html.twig
+++ b/src/UiComponents/SearchBar/SearchBar.html.twig
@@ -30,7 +30,7 @@
                     {% else %}
                         <div class="SearchDropdown-results">
                             {% for product in this.products %}
-                                {{ include('@components/Organisms/ProductCard/ProductCard.html.twig', product) }}
+                                {{ component('Flexy:ProductCard', {product}) }}
                             {% endfor %}
                         </div>
                     {% endif %}

--- a/src/UiComponents/SimilarContent/SimilarContent.php
+++ b/src/UiComponents/SimilarContent/SimilarContent.php
@@ -21,6 +21,8 @@ use Thelia\Api\Service\DataAccess\DataAccessService;
 class SimilarContent
 {
     public array $similarContents;
+    public int $itemsPerPage = 3;
+    public ?int $folderId = null;
 
     public function __construct(private DataAccessService $dataAccessService)
     {
@@ -36,10 +38,13 @@ class SimilarContent
     public function similarContents(): array
     {
         $contents = $this->dataAccessService->resources('/api/front/contents', [
-            'itemsPerPage' => 3,
+            'itemsPerPage' => $this->itemsPerPage,
+            'contentFolders.folder.id' => $this->folderId,
+            'visible' => true,
         ]);
 
-        return array_map(fn ($item) => [
+        return array_map(fn($item) => [
+            'id' => $item['id'],
             'title' => $item['i18ns']['title'] ?? '',
             'date' => $item['createdAt'],
             'url' => $item['publicUrl'],

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -42,12 +42,12 @@ module.exports = {
       screens: {
         xxs   : '320px',
         '3xl' : '1920px',
-        max2xl: { max: '1680px' },
-        maxXl : { max: '1366px' },
-        maxLg : { max: '1024px' },
-        maxMd : { max: '768px' },
-        maxSm : { max: '390px' },
-        maxXs : { max: '321px' }
+        max2xl: { max: '1679px' },
+        maxXl : { max: '1365px' },
+        maxLg : { max: '1023px' },
+        maxMd : { max: '767px' },
+        maxSm : { max: '639px' },
+        maxXs : { max: '389px' }
       }
     },
     screens : {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,6 +4,7 @@ module.exports = {
     './components/**/*.{twig,ts,js,json}',
     './src/UiComponents/**/*.{twig,ts,js,json}',
     './form/**/*.twig',
+    './blocks/**/*.twig',
     './*.twig'
   ],
   theme  : {


### PR DESCRIPTION
### Cette PR apporte un ensemble de correctifs et de nouvelles fonctionnalités génériques identifiés lors d'un projet d'intégration, tous applicables à Flexy en upstream.

---
**Header mobile — système de panneaux générique**

Refactoring du header mobile pour remplacer le toggle de menu unique et codé en dur par un système de panneaux générique. Le header_controller.js expose désormais une action togglePanel(event) pilotée par un paramètre panel, avec des méthodes privées #findPanel() et #closeAll(). Il devient ainsi simple d'ajouter de nouveaux panneaux (recherche, panier, langue…) sans toucher au contrôleur.

Comme première utilisation de ce système, un panneau de sélection de langue (composant LangSelect) a été ajouté pour le mobile.

Le comportement du bouton retour et le fichier menu.css ont été mis à jour en conséquence, avec notamment une nouvelle classe de base .MobilePanel pour les tiroirs plein écran sur mobile.

---
**Correctifs et petites améliorations**

- Breakpoints max Tailwind : toutes les valeurs max: corrigées de −1px pour éviter le chevauchement à la valeur exacte du breakpoint (maxLg: 1023px au lieu de 1024px, etc.). maxSm était également erroné (était à 390px, corrigé à 639px).
- Correction BEM sur SubheaderTitle : classe de modificateur corrigée de Subheader-titleOnly en Subheader--titleOnly (élément vs. modificateur).
- SearchBar : remplacement de include('@components/ProductCard') par component('Flexy:ProductCard', {product}) pour cohérence avec le reste du code.
- item_header_controller : correction de la résolution du target quand l'élément cliqué contient une icône SVG (le clic ne remontait pas au bon target).

---
**SimilarContent — nouvelles options**

Ajout des props $itemsPerPage et $folderId sur le composant SimilarContent, ainsi que le filtre visible: true et le champ id dans le tableau retourné (manquant, ce qui causait des erreurs de résolution d'image dans SimilarContentCard).

---
**Page produit — calcul de la liste d'images déplacé en PHP**

La fusion des images PSE et des images produit (auparavant effectuée directement dans Twig) est désormais calculée dans Product::setImages() et exposée comme tableau unique $images. Le template est simplifié en images: images.

---
**Contrôleurs — suppressions de dépréciations**

- Annotation\Route remplacé par Attribute\Route dans PasswordController et CustomerController.
- `Tlog::getInstance()->error()` remplacé par `$this->logger->error()`(LoggerInterface injecté) dans FlexyController, CustomerController et AccountController. L'import use Thelia\Log\Tlog inutilisé supprimé de CheckoutController.   
                                                                                                                                              
---
**Pagination — composant Button**

Les liens précédent/suivant dans Pagination.html.twig sont désormais rendus via component('Flexy:Button', {color: 'minimal'}). L'espacement utilise les utilitaires Tailwind (mr-3 / ml-3) plutôt que des classes CSS dédiées. Les règles désormais inutiles --isPrev, --isNext, icône et texte ont été supprimées de pagination.css.

---
**FolderContents — liste de contenus paginée**

Nouveau TwigComponent Flexy:FolderContents qui interroge /api/front/contents (JSON-LD) pour un dossier donné et affiche une grille responsive avec pagination. Le template folder.html.twig délègue désormais l'affichage des contenus à ce composant plutôt qu'une boucle resources() statique. La grille utilise auto-fill minmax(240px, 1fr) pour un nombre de colonnes flexible.

---
**TheliaBlocks — templates de blocs génériques**

Ajout des templates Twig pour les types de blocs TheliaBlocks les plus courants :

blockText, blockHighlight, blockSeparator, blockTable, blockVideo, blockGroup, blockAccordion, multiColumns, blockProduct

Également ajoutés :
- assets/css/wysiwyg.css — styles rich text génériques (titres, listes, liens, citations…)
- assets/css/blocks.css — styles spécifiques à blockTable et blockVideo
- Chemin ./blocks/**/*.twig ajouté dans content de tailwind.config.js

---
**BlocksToc — table des matières automatique**

Nouveau composant Flexy:BlocksToc qui lit les blocs blockTitle d'un élément donné et affiche une sidebar de table des matières sticky (visible à partir du breakpoint xl). Les titres dans le rendu des blocs reçoivent des ancres via un nouveau filtre Twig slug_id (SlugIdExtension), qui produit des ancres lisibles et URL-safe en combinant un slug tronqué du texte avec un court préfixe de l'ID du bloc.

Le layout de content.html.twig a été mis à jour en deux colonnes flex (article + sidebar ToC), avec des points de surcharge {% block table_of_contents %} et {% block similar_content %} pour les templates enfants. scroll-behavior: smooth ajouté globalement.