### PR TITLE
Perf/liip filters

### DIFF
--- a/components/Layout/Header/Header.html.twig
+++ b/components/Layout/Header/Header.html.twig
@@ -16,7 +16,7 @@
     <div class="Header-top">
         <div class="flex">
             <div class="flex items-center self-center h-full">
-                <a href="/" class="Header-logo">
+                <a href="/" class="Header-logo" aria-label="{{ 'Home'|trans }}">
                     {{ ux_icon('thelia') }}
                 </a>
             </div>

--- a/components/Molecules/Breadcrumb/Breadcrumb.html.twig
+++ b/components/Molecules/Breadcrumb/Breadcrumb.html.twig
@@ -4,29 +4,26 @@
 {% if breadcrumb is not empty %}
     <aside class="Breadcrumb {{ classes }}" aria-label="Fil d'Ariane">
         <nav>
-            <ol class="Breadcrumb-list" itemscope itemtype="https://schema.org/BreadcrumbList">
-                <li class="Breadcrumb-item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
-                    <a href="/" class="Breadcrumb-link" itemprop="item">
-                        <span itemprop="name">
+            <ol class="Breadcrumb-list">
+                <li class="Breadcrumb-item">
+                    <a href="/" class="Breadcrumb-link">
+                        <span>
                             {{ 'Home'|trans }}
                         </span>
                     </a>
-                    <meta itemprop="position" content="1"/>
                 </li>
                 {% for item in breadcrumb %}
-                    <li class="Breadcrumb-item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+                    <li class="Breadcrumb-item">
                         {% if loop.index != loop.last %}
-                            <a class="Breadcrumb-link" href="{{ item.url }}" itemprop="item">
-                                <span itemprop="name" class="Breadcrumb-link" itemprop="item">
+                            <a class="Breadcrumb-link" href="{{ item.url }}">
+                                <span class="Breadcrumb-link">
                                     {{ item.title }}
                                 </span>
                             </a>
-                            <meta itemprop="position" content="{{ loop.index + 1 }}"/>
                         {% else %}
-                            <span class="no-underline Breadcrumb-link" itemprop="name" aria-current="page">
+                            <span class="no-underline Breadcrumb-link" aria-current="page">
                                 {{ item.title }}
                             </span>
-                            <meta itemprop="position" content="{{ loop.index + 1 }}"/>
                         {% endif %}
                     </li>
                 {% endfor %}

--- a/components/Molecules/Button/Quantity.html.twig
+++ b/components/Molecules/Button/Quantity.html.twig
@@ -8,11 +8,11 @@
 {% set plusHidden = plusHidden|default(false) %}
 
 <div role="button" class="Button Button-quantity {{ classes }} {% if disabled %}disabled{% endif %}"  >
-    <button type="button" {% if btnLiveAction %} data-action="live#action" data-live-action-param="{{ btnLiveAction }}" data-live-quantity-param="{{ value - 1 }}" {% else %} data-qty="minus" {% endif %} {% if minusDisabled %} disabled {% endif %} data-loading="addClass(pointer-events-none)">
+    <button type="button" aria-label="{{ 'Decrease quantity'|trans }}" {% if btnLiveAction %} data-action="live#action" data-live-action-param="{{ btnLiveAction }}" data-live-quantity-param="{{ value - 1 }}" {% else %} data-qty="minus" {% endif %} {% if minusDisabled %} disabled {% endif %} data-loading="addClass(pointer-events-none)">
         -
     </button>
-    <input type="number" name="{{ name }}" {% if disabled %} disabled {% endif %} {% if min is not null %} min="{{ min }}" {% endif %} {% if max is not null %} max="{{ max }}" {% endif %} value='{{ value }}'>
-    <button type="button" {% if plusHidden %} style="visibility: hidden;" {% endif %} {% if btnLiveAction %} data-action="live#action" data-live-action-param="{{ btnLiveAction }}" data-live-quantity-param="{{ value + 1 }}" {% else %} data-qty="plus" {% endif %} {% if plusDisabled or plusHidden %} disabled {% endif %} data-loading="addClass(pointer-events-none)">
+    <input type="number" name="{{ name }}" aria-label="{{ 'Quantity'|trans }}" {% if disabled %} disabled {% endif %} {% if min is not null %} min="{{ min }}" {% endif %} {% if max is not null %} max="{{ max }}" {% endif %} value='{{ value }}'>
+    <button type="button" aria-label="{{ 'Increase quantity'|trans }}" {% if plusHidden %} style="visibility: hidden;" {% endif %} {% if btnLiveAction %} data-action="live#action" data-live-action-param="{{ btnLiveAction }}" data-live-quantity-param="{{ value + 1 }}" {% else %} data-qty="plus" {% endif %} {% if plusDisabled or plusHidden %} disabled {% endif %} data-loading="addClass(pointer-events-none)">
         +
     </button>
 </div>

--- a/components/Organisms/CategoryCard/CategoryCard.html.twig
+++ b/components/Organisms/CategoryCard/CategoryCard.html.twig
@@ -10,7 +10,7 @@
       {{getImages({
         'source_id': id,
         'source_type': 'category',
-        filters: 'default',
+        filters: 'category',
         alt: ('Category'|trans)~' '~title,
         'img_attrs': {
           loading: 'lazy',

--- a/components/Organisms/CategoryCard/CategoryCard.html.twig
+++ b/components/Organisms/CategoryCard/CategoryCard.html.twig
@@ -10,14 +10,18 @@
       {{getImages({
         'source_id': id,
         'source_type': 'category',
-        filters: 'category',
+        filters: {
+          '1024px': 'category',
+          '768px': 'category_md',
+          'default': 'category_sm'
+        },
         alt: ('Category'|trans)~' '~title,
         'img_attrs': {
           loading: 'lazy',
           width: 190,
           height: 190
         },
-        wrapper: 'figure',
+        wrapper: 'picture',
         'wrapper_attrs': {
           'class' : 'CategoryCard-img'
         },

--- a/components/Organisms/CategoryCard/categoryCard.css
+++ b/components/Organisms/CategoryCard/categoryCard.css
@@ -42,6 +42,7 @@
   }
 
   &-img {
+    display: block;
     overflow: hidden;
     height: 187px;
     @screen sm {

--- a/config/packages/liip_imagine_thelia.yaml
+++ b/config/packages/liip_imagine_thelia.yaml
@@ -28,6 +28,11 @@ liip_imagine:
       format: webp
       filters:
         downscale: { max: [500, 500] }
+    block_image:
+      quality: 82
+      format: webp
+      filters:
+        downscale: { max: [800, 800] }
     add_to_cart:
       quality: 82
       format: webp

--- a/config/packages/liip_imagine_thelia.yaml
+++ b/config/packages/liip_imagine_thelia.yaml
@@ -19,6 +19,22 @@ liip_imagine:
 
   filter_sets:
     default:
+      quality: 82
+      format: webp
+      filters:
+        downscale: { max: [1200, 1200] }
     add_to_cart:
+      quality: 82
+      format: webp
+      filters:
+        downscale: { max: [400, 400] }
     order_card:
+      quality: 82
+      format: webp
+      filters:
+        downscale: { max: [200, 200] }
     order_card_detail:
+      quality: 82
+      format: webp
+      filters:
+        downscale: { max: [400, 400] }

--- a/config/packages/liip_imagine_thelia.yaml
+++ b/config/packages/liip_imagine_thelia.yaml
@@ -23,6 +23,11 @@ liip_imagine:
       format: webp
       filters:
         downscale: { max: [1200, 1200] }
+    category:
+      quality: 82
+      format: webp
+      filters:
+        downscale: { max: [500, 500] }
     add_to_cart:
       quality: 82
       format: webp

--- a/config/packages/liip_imagine_thelia.yaml
+++ b/config/packages/liip_imagine_thelia.yaml
@@ -28,6 +28,16 @@ liip_imagine:
       format: webp
       filters:
         downscale: { max: [500, 500] }
+    category_md:
+      quality: 80
+      format: webp
+      filters:
+        downscale: { max: [400, 400] }
+    category_sm:
+      quality: 80
+      format: webp
+      filters:
+        downscale: { max: [300, 300] }
     block_image:
       quality: 82
       format: webp

--- a/src/UiComponents/Button/button.css
+++ b/src/UiComponents/Button/button.css
@@ -188,6 +188,9 @@
   button {
     padding-left: 3px;
     padding-right: 3px;
+    min-width: rem-convert(44px);
+    min-height: rem-convert(44px);
+    align-self: stretch;
   }
   &.disabled,
   &.disabled:hover {

--- a/translations/messages.en_US.yaml
+++ b/translations/messages.en_US.yaml
@@ -45,6 +45,8 @@ Add to cart: Add to cart
 New: New
 Your product has been added to the cart: Your product has been added to the cart
 Quantity:: Quantity:
+Decrease quantity: Decrease quantity
+Increase quantity: Increase quantity
 has been removed from your cart.: has been removed from your cart.
 Restore: Restore
 Reviews: Reviews

--- a/translations/messages.fr_FR.yaml
+++ b/translations/messages.fr_FR.yaml
@@ -45,6 +45,9 @@ Add to cart: Ajouter au panier
 New: Nouveau
 Your product has been added to the cart: Votre produit a été ajouté au panier
 Quantity:: Quantité :
+Quantity: Quantité
+Decrease quantity: Diminuer la quantité
+Increase quantity: Augmenter la quantité
 Color: Couleur
 has been removed from your cart.: a été retiré de votre panier.
 Restore: Restaurer


### PR DESCRIPTION
## Images (LiipImagine)
- Fill in empty `filter_sets` (`default`, `add_to_cart`, `order_card`,                                                                                                                                                                
    `order_card_detail`) — they were serving full-size originals. Add                                                                                                                                                                   
    quality + `webp` + `downscale`.                                                                                                                                                                                                     
- Add `category` (500px) and `block_image` (800px) filters.                                                                                                                                                                           
- Responsive `category_md` (400px) / `category_sm` (300px) + switch                                                                                                                                                                   
    `CategoryCard` to `<picture>` with per-breakpoint filter map.
    
## Accessibility
- `aria-label` on logo and quantity controls; 44×44px touch target on ± buttons.                                                                                                                                                      
- fr_FR + en_US translations.  

## SEO
- Remove duplicate `BreadcrumbList` microdata (keep SEOne JSON-LD).                                                                                                                                                                   
- Add `SEOneMicroData()` block in `base.html.twig